### PR TITLE
Updating include-all to 4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "bunyan": "^1.8.1",
     "callsite": "^1.0.0",
     "depd": "^1.1.0",
-    "include-all": "^2.0.0",
+    "include-all": "^4.0.3",
     "inflect": "^0.3.0",
     "lodash": "^4.13.1",
     "pg": "^6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@sailshq/lodash@^3.10.2":
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/@sailshq/lodash/-/lodash-3.10.2.tgz#1567d47345364c2c2e2077bc113487b1dfe62154"
+
 JSONStream@^1.0.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -2027,11 +2031,12 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
-include-all@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/include-all/-/include-all-2.0.0.tgz#0f8ecc64ddab3a2fa860e5b42b084a6178a56275"
+include-all@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/include-all/-/include-all-4.0.3.tgz#65f06e8f11894b1a7b5ec1fc97e6b3392f7cfa75"
   dependencies:
-    lodash "3.10.1"
+    "@sailshq/lodash" "^3.10.2"
+    merge-dictionaries "^0.0.3"
 
 indent-string@^2.1.0:
   version "2.1.0"
@@ -2599,13 +2604,13 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash@3.10.1, lodash@^3.7.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
 lodash@4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.12.0.tgz#2bd6dc46a040f59e686c972ed21d93dc59053258"
+
+lodash@^3.7.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
 lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
@@ -2691,6 +2696,12 @@ meow@^3.3.0, meow@^3.7.0:
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
+merge-dictionaries@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/merge-dictionaries/-/merge-dictionaries-0.0.3.tgz#c4de4d58dbb25e4c2823aa30cb8e1539069eb757"
+  dependencies:
+    "@sailshq/lodash" "^3.10.2"
 
 methods@1.x, methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION

Please update [include-all](https://npmjs.org/package/include-all) to version 4.0.3.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```be207c8```](https://github.com/balderdashy/include-all/commit/be207c8cdb0d64db5d49515a1831f8c858159aa1) ```4.0.3```
 * [```0212ddc```](https://github.com/balderdashy/include-all/commit/0212ddcee652d71fc90edf0d441c56e40f35d956) ```Use different separators to avoid issues when copy&hellip;```
 * [```b323d94```](https://github.com/balderdashy/include-all/commit/b323d9413e49a597ee66ab0b380e08a290ce6376) ```4.0.2```
 * [```12ee855```](https://github.com/balderdashy/include-all/commit/12ee855b935d8339afb34989c8e674456f4dabbf) ```Use 'message' instead of mutating stack.```
 * [```e193dc7```](https://github.com/balderdashy/include-all/commit/e193dc731f8858f74c873d726136f60cb50460fb) ```4.0.1```
 * [```cf7357c```](https://github.com/balderdashy/include-all/commit/cf7357c348be285b1a80a74a308159c4dfd06d6f) ```Wrap unhandled exception```
 * [```6d7e150```](https://github.com/balderdashy/include-all/commit/6d7e1501dc9b6ce081670db0dc5164fb6270e139) ```4.0.0```
 * [```ae5e35e```](https://github.com/balderdashy/include-all/commit/ae5e35ed971db055b675e61ed8563fbe55a0c1e8) ```Throw error if a duplicate key is loaded.```
 * [```a3a87a2```](https://github.com/balderdashy/include-all/commit/a3a87a29b86f6a3d038a8879fb4cb5d8b2c8a914) ```3.0.1```
 * [```a66c52c```](https://github.com/balderdashy/include-all/commit/a66c52c1a94dd356a846f2aa844fed178b5033d8) ```Loosen up merge-dictionaries dependency range```
 * [```b74f353```](https://github.com/balderdashy/include-all/commit/b74f353195741d48986b88e24a4da9a7b6c53252) ```3.0.0```
 * [```6c877b0```](https://github.com/balderdashy/include-all/commit/6c877b0cb2d7ef6ff2d46acd43039ba0cc6d228a) ```Merge pull request #19 from balderdashy/use-sailshq-lodash```
 * [```80834c3```](https://github.com/balderdashy/include-all/commit/80834c3af880556febe13a844e0085dccb5e2240) ```Replace "lodash" with "sailshq/lodash"```
 * [```4c34bd3```](https://github.com/balderdashy/include-all/commit/4c34bd34769107018c9dee3a8c70e2f7aa4ca7fd) ```Merge pull request #18 from balderdashy/use-merge-dictionary-module```
 * [```d2f8bb7```](https://github.com/balderdashy/include-all/commit/d2f8bb7e6455f0409a6dfac60f87ea8142aa0199) ```Merge branch 'master' into use-merge-dictionary-mo&hellip;```


See the full [change log](https://github.com/mikermcneil/include-all/compare/d21d8c495d83d24feae88ee02921b3a9183e80e4...be207c8cdb0d64db5d49515a1831f8c858159aa1) for everything that changed in this release.