### PR TITLE
Updating sinon to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jsonwebtoken": "^7.0.1",
     "minimatch": "^3.0.3",
     "mocha": "^3.2.0",
-    "sinon": "^1.17.4",
+    "sinon": "^2.1.0",
     "sinon-chai": "^2.8.0",
     "sqlite3": "^3.1.4",
     "stream": "0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1262,6 +1262,10 @@ diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
+diff@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
 doctrine@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
@@ -1685,11 +1689,11 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
-    samsam "~1.1"
+    samsam "1.x"
 
 formidable@^1.0.14, formidable@^1.0.17:
   version "1.1.1"
@@ -2058,10 +2062,6 @@ inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, i
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inherits@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
-
 ini@^1.3.2, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
@@ -2236,6 +2236,10 @@ is-utf8@^0.2.0:
 is-windows@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.0.tgz#c61d61020c3ebe99261b781bd3d1622395f547f8"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -2615,9 +2619,9 @@ log-driver@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2817,6 +2821,10 @@ mv@~2:
 nan@^2.0.8, nan@^2.3.0, nan@^2.3.3, nan@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.4.0.tgz#fb3c59d45fe4effe215f0b890f8adf6eb32d2232"
+
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -3027,6 +3035,12 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -3501,9 +3515,9 @@ safe-json-stringify@^1.0.3, safe-json-stringify@~1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz#81a098f447e4bbc3ff3312a243521bc060ef5911"
 
-samsam@1.1.2, samsam@~1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
 
 select-hose@^2.0.0:
   version "2.0.0"
@@ -3620,14 +3634,18 @@ sinon-chai@^2.8.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.9.0.tgz#34d820042bc9661a14527130d401eb462c49bb84"
 
-sinon@^1.17.4:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+sinon@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.1.0.tgz#e057a9d2bf1b32f5d6dd62628ca9ee3961b0cafb"
   dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -3885,6 +3903,10 @@ terraformer@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/terraformer/-/terraformer-1.0.7.tgz#d8a19a56fbf25966ea062d21f515b93589702d69"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-extensions@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.4.0.tgz#c385d2e80879fe6ef97893e1709d88d9453726e9"
@@ -3968,6 +3990,10 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
+type-detect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.0.tgz#62053883542a321f2f7b25746dc696478b18ff6b"
+
 type-is@~1.6.14:
   version "1.6.14"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.14.tgz#e219639c17ded1ca0789092dd54a03826b817cb2"
@@ -4031,12 +4057,6 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-"util@>=0.10.3 <1":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
-  dependencies:
-    inherits "2.0.1"
 
 utils-merge@1.0.0:
   version "1.0.0"


### PR DESCRIPTION

Please update [sinon](https://npmjs.org/package/sinon) to version 2.1.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```9157d41```](https://github.com/sinonjs/sinon/commit/9157d41cd95cb29ea1154083787df2406f2b37cc) ```Update docs/changelog.md and set new release id in&hellip;```
 * [```17e735d```](https://github.com/sinonjs/sinon/commit/17e735d720dba2a5a6e71297711994adbb87a6ab) ```Add release documentation for v2.1.0```
 * [```90a5d8e```](https://github.com/sinonjs/sinon/commit/90a5d8eddeffbbf259739da40c81f5d261385566) ```2.1.0```
 * [```db6e03b```](https://github.com/sinonjs/sinon/commit/db6e03bc0fb68a17fbf0b230605a6d6bad0060a8) ```Update Changelog.txt and AUTHORS for new release```
 * [```a3eebd9```](https://github.com/sinonjs/sinon/commit/a3eebd99d730bd56ecd96a01760c0b54b4a769b9) ```Build package as part of postversion step```
 * [```fd79000```](https://github.com/sinonjs/sinon/commit/fd790000468ef9157d1ab69c8637b7a251fd1ae3) ```Fix GitHub asset URL```
 * [```6a7c801```](https://github.com/sinonjs/sinon/commit/6a7c801193e6cd1cb277fc2d96b84fd544d03887) ```Redesign the template (#1339)```
 * [```354c84c```](https://github.com/sinonjs/sinon/commit/354c84c79f39b0b40322a3654acec2a902178550) ```Merge pull request #1337 from timcosta/add_called_immediately_before_after```
 * [```a957ef3```](https://github.com/sinonjs/sinon/commit/a957ef3295d56f24e11ff3b5078fc4ce41ba60b5) ```update spy names across four tests```
 * [```3aa9919```](https://github.com/sinonjs/sinon/commit/3aa9919b72089e824ed2f51b5af5a6bb2bb2976a) ```[feature] adds spy.calledImmediatelyBefore and spy&hellip;```
 * [```e401337```](https://github.com/sinonjs/sinon/commit/e4013371207d55f91d9fc99d0ff85532e3ed57e0) ```Merge pull request #1331 from mroderick/remove-next-release-from-docs```
 * [```af504b9```](https://github.com/sinonjs/sinon/commit/af504b9a02f0ea647522c61352059d03989044d6) ```Remove documentation of the 2.x pre-releases```
 * [```8bec6dd```](https://github.com/sinonjs/sinon/commit/8bec6dddb24e23bc9e417906ab6b3be75cd5b757) ```Remove @next instructions from documentation```
 * [```fc749fa```](https://github.com/sinonjs/sinon/commit/fc749fa47d78b34e15a3a6de01a23ab2da626e89) ```Merge pull request #1333 from eauc/master```
 * [```2058030```](https://github.com/sinonjs/sinon/commit/205803025bc3cfa44d3d56ca5c15845b4a15f99c) ```Add missing space from deprecated message (#1334)```


See the full [change log](https://github.com/sinonjs/sinon/compare/c8f5355715adbd7d10f15eca1566d3301b85bd9a...9157d41cd95cb29ea1154083787df2406f2b37cc) for everything that changed in this release.